### PR TITLE
Exposed StopRecording() method of the native API

### DIFF
--- a/Xamarin.Smartlook.Android/SmartlookImplementation.cs
+++ b/Xamarin.Smartlook.Android/SmartlookImplementation.cs
@@ -11,5 +11,10 @@
         {
             Com.Smartlook.Sdk.Smartlook.Smartlook.StartRecording();
         }
+
+        public void StopRecording()
+        {
+            Com.Smartlook.Sdk.Smartlook.Smartlook.StopRecording();
+        }
     }
 }

--- a/Xamarin.Smartlook.Interfaces/Smartlook.cs
+++ b/Xamarin.Smartlook.Interfaces/Smartlook.cs
@@ -1,9 +1,24 @@
 ﻿namespace Xamarin.Smartlook
 {
+    /// <summary>
+    /// Represents an entry point to Smartlook client library
+    /// </summary>
     public interface ISmartlook
     {
+        /// <summary>
+        /// Configures the Smartlook client to use a specific API key
+        /// </summary>
+        /// <param name="apiKey">API key to authenticate with Smartlook</param>
         void SetupWithKey(string apiKey);
 
+        /// <summary>
+        /// Starts session recording
+        /// </summary>
         void StartRecording();
+
+        /// <summary>
+        /// Stops session recording
+        /// </summary>
+        void StopRecording();
     }
 }

--- a/Xamarin.Smartlook.Interfaces/SmartlookFactory.cs
+++ b/Xamarin.Smartlook.Interfaces/SmartlookFactory.cs
@@ -1,7 +1,14 @@
 ﻿namespace Xamarin.Smartlook
 {
+    /// <summary>
+    /// Represents an abstract factory of Smartlook clients
+    /// </summary>
     public interface ISmartlookFactory
     {
+        /// <summary>
+        /// Creates a new instance of platform-specific Smartlook client
+        /// </summary>
+        /// <returns></returns>
         ISmartlook CreateSdk();
     }
 }

--- a/Xamarin.Smartlook.iOS.Bindings/ApiDefinition.cs
+++ b/Xamarin.Smartlook.iOS.Bindings/ApiDefinition.cs
@@ -23,5 +23,9 @@ namespace SmartlookSdk
         [Static]
         [Export("startRecording")]
         void StartRecording();
+
+        [Static]
+        [Export("stopRecording")]
+        void StopRecording();
     }
 }

--- a/Xamarin.Smartlook.iOS/SmartlookImplementation.cs
+++ b/Xamarin.Smartlook.iOS/SmartlookImplementation.cs
@@ -18,5 +18,10 @@
         {
             SmartlookSdk.Smartlook_PublicInterface.StartRecording(this.implementation);
         }
+
+        public void StopRecording()
+        {
+            SmartlookSdk.Smartlook_PublicInterface.StopRecording(this.implementation);
+        }
     }
 }

--- a/Xamarin.Smartlook/SmartlookImplementation.cs
+++ b/Xamarin.Smartlook/SmartlookImplementation.cs
@@ -13,5 +13,10 @@ namespace Xamarin.Smartlook
         {
             throw new NotImplementedException("This is just the bait");
         }
+
+        public void StopRecording()
+        {
+            throw new NotImplementedException("This is just the bait");
+        }
     }
 }


### PR DESCRIPTION
Required to stop recording session immediately after the user has revoked their consent.